### PR TITLE
Ajout de la page maths MP2I au menu maths

### DIFF
--- a/maths.html
+++ b/maths.html
@@ -42,6 +42,7 @@
 		<tr><td> &bull; <a id="math" href="maths/DS.html"> DS </a></td></tr> 
 		<tr><td> &bull; <a id="math" href="maths/mpsi1.html"> MPSI 1 </a></td></tr>  
 		<tr><td> &bull; <a id="math" href="maths/mpsi2.html"> MPSI 2 </a></td></tr>  
+		<tr><td> &bull; <a id="math" href="maths/mp2i.html"> MP2I </a></td></tr>  
               </tbody>
 	    </table>
 	  </div>


### PR DESCRIPTION
Résolution de l'absence du lien vers la page maths/mp2i.html dans le portail maths, qui rendait la naviagtion mobile difficile.

(Photo de l'état avant merge)
![image](https://github.com/user-attachments/assets/c82c182d-80ad-4ab0-b897-37e997f0746a)